### PR TITLE
feat: display model ID for selected traits on profile page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,6 +4,10 @@ class ProfilesController < ApplicationController
   def show
     @user = Current.user
     authorize @user
+    
+    # Get the actual model IDs for the selected traits
+    @selected_text_model_id = @user.text_model
+    @selected_image_model_id = @user.image_model
   end
 
   def edit

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -44,13 +44,19 @@
           <div>
             <dt class="text-sm font-medium text-gray-500">Preferred Text Model</dt>
             <dd class="mt-1 text-sm text-gray-900">
-              <%= @user.preferred_text_model.titleize %>
+              <div class="font-medium"><%= @user.preferred_text_model.present? ? @user.preferred_text_model.titleize : "Default" %></div>
+              <% if @selected_text_model_id.present? %>
+                <div class="text-xs text-gray-600 mt-1">Model: <%= @selected_text_model_id %></div>
+              <% end %>
             </dd>
           </div>
           <div>
             <dt class="text-sm font-medium text-gray-500">Preferred Image Model</dt>
             <dd class="mt-1 text-sm text-gray-900">
-              <%= @user.preferred_image_model.titleize %>
+              <div class="font-medium"><%= @user.preferred_image_model.present? ? @user.preferred_image_model.titleize : "Default" %></div>
+              <% if @selected_image_model_id.present? %>
+                <div class="text-xs text-gray-600 mt-1">Model: <%= @selected_image_model_id %></div>
+              <% end %>
             </dd>
           </div>
 


### PR DESCRIPTION
Show the actual model ID associated with user's selected text and image traits on the profile page. This provides transparency about which specific model is being used for each trait selection.

Changes:
- Add model ID resolution in ProfilesController#show
- Update profile view to display both trait name and model ID
- Improve fallback handling for unset preferences