### PR TITLE
feat: add GitHub MCP server configuration

### DIFF
--- a/.ona/mcp-config.json
+++ b/.ona/mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "name": "github",
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "ghcr.io/github/github-mcp-server"],
+      "disabled": false,
+      "timeout": 30
+    }
+  }
+}


### PR DESCRIPTION
Add GitHub MCP server configuration to .ona/mcp-config.json to enable GitHub integration through Docker-based MCP server.